### PR TITLE
Universal reverence visitables

### DIFF
--- a/include/boost/variant/detail/apply_visitor_binary.hpp
+++ b/include/boost/variant/detail/apply_visitor_binary.hpp
@@ -264,7 +264,14 @@ private:
 }} // namespace detail::variant
 
 template <typename Visitor, typename Visitable1, typename Visitable2>
-inline decltype(auto) apply_visitor(Visitor& visitor, Visitable1& visitable1, Visitable2& visitable2,
+inline decltype(auto) apply_visitor(Visitor& visitor,
+#ifdef USE_UNIVERSAL_REF
+        Visitable1&& visitable1,
+        Visitable2&& visitable2,
+#else
+        Visitable1& visitable1,
+        Visitable2& visitable2,
+#endif
     typename boost::disable_if<
         boost::detail::variant::has_result_type<Visitor>
     >::type* = 0)
@@ -277,7 +284,14 @@ inline decltype(auto) apply_visitor(Visitor& visitor, Visitable1& visitable1, Vi
 }
 
 template <typename Visitor, typename Visitable1, typename Visitable2>
-inline decltype(auto) apply_visitor(const Visitor& visitor, Visitable1& visitable1, Visitable2& visitable2,
+inline decltype(auto) apply_visitor(const Visitor& visitor,
+#ifdef USE_UNIVERSAL_REF
+        Visitable1&& visitable1,
+        Visitable2&& visitable2,
+#else
+        Visitable1& visitable1,
+        Visitable2& visitable2,
+#endif
     typename boost::disable_if<
         boost::detail::variant::has_result_type<Visitor>
     >::type* = 0)
@@ -289,33 +303,6 @@ inline decltype(auto) apply_visitor(const Visitor& visitor, Visitable1& visitabl
     return boost::apply_visitor(unwrapper, visitable1);
 }
 
-//universal reference visitables
-
-template <typename Visitor, typename Visitable1, typename Visitable2>
-inline decltype(auto) apply_visitor(Visitor& visitor, Visitable1&& visitable1, Visitable2&& visitable2,
-    typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
-{
-    ::boost::detail::variant::apply_visitor_binary_unwrap_cpp14<
-          Visitor, Visitable2
-        > unwrapper(visitor, visitable2);
-
-    return boost::apply_visitor(unwrapper, visitable1);
-}
-
-template <typename Visitor, typename Visitable1, typename Visitable2>
-inline decltype(auto) apply_visitor(const Visitor& visitor, Visitable1&& visitable1, Visitable2&& visitable2,
-    typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
-{
-    ::boost::detail::variant::apply_visitor_binary_unwrap_cpp14<
-          const Visitor, Visitable2
-        > unwrapper(visitor, visitable2);
-
-    return boost::apply_visitor(unwrapper, visitable1);
-}
 
 #endif // !defined(BOOST_NO_CXX14_DECLTYPE_AUTO) && !defined(BOOST_NO_CXX11_DECLTYPE_N3276)
 

--- a/include/boost/variant/detail/apply_visitor_unary.hpp
+++ b/include/boost/variant/detail/apply_visitor_unary.hpp
@@ -21,6 +21,7 @@
 #include <boost/core/enable_if.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/remove_reference.hpp>
 #endif
 
 #if !defined(BOOST_NO_CXX14_DECLTYPE_AUTO) && !defined(BOOST_NO_CXX11_DECLTYPE_N3276)
@@ -165,44 +166,35 @@ struct result_wrapper1
 }} // namespace detail::variant
 
 template <typename Visitor, typename Visitable>
-inline decltype(auto) apply_visitor(Visitor& visitor, Visitable& visitable,
+inline decltype(auto) apply_visitor(Visitor& visitor,
+#ifdef USE_UNIVERSAL_REF
+        Visitable&& visitable,
+#else
+        Visitable& visitable,
+#endif
     typename boost::disable_if<
         boost::detail::variant::has_result_type<Visitor>
     >::type* = 0)
 {
-    boost::detail::variant::result_wrapper1<Visitor, Visitable> cpp14_vis(visitor);
+    boost::detail::variant::result_wrapper1<Visitor, typename remove_reference<Visitable>::type> cpp14_vis(visitor);
     return visitable.apply_visitor(cpp14_vis);
 }
 
 template <typename Visitor, typename Visitable>
-inline decltype(auto) apply_visitor(const Visitor& visitor, Visitable& visitable,
+inline decltype(auto) apply_visitor(const Visitor& visitor,
+#ifdef USE_UNIVERSAL_REF
+        Visitable&& visitable,
+#else
+        Visitable& visitable,
+#endif
     typename boost::disable_if<
         boost::detail::variant::has_result_type<Visitor>
     >::type* = 0)
 {
-    boost::detail::variant::result_wrapper1<const Visitor, Visitable> cpp14_vis(visitor);
+    boost::detail::variant::result_wrapper1<const Visitor, typename remove_reference<Visitable>::type> cpp14_vis(visitor);
     return visitable.apply_visitor(cpp14_vis);
 }
 
-template <typename Visitor, typename Visitable>
-inline decltype(auto) apply_visitor(Visitor& visitor, Visitable&& visitable,
-    typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
-{
-    boost::detail::variant::result_wrapper1<Visitor, Visitable> cpp14_vis(visitor);
-    return visitable.apply_visitor(cpp14_vis);
-}
-
-template <typename Visitor, typename Visitable>
-inline decltype(auto) apply_visitor(const Visitor& visitor, Visitable&& visitable,
-    typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
-{
-    boost::detail::variant::result_wrapper1<const Visitor, Visitable> cpp14_vis(visitor);
-    return visitable.apply_visitor(cpp14_vis);
-}
 
 #endif // !defined(BOOST_NO_CXX14_DECLTYPE_AUTO) && !defined(BOOST_NO_CXX11_DECLTYPE_N3276)
 

--- a/include/boost/variant/detail/multivisitors_cpp11_based.hpp
+++ b/include/boost/variant/detail/multivisitors_cpp11_based.hpp
@@ -151,7 +151,7 @@ namespace detail { namespace variant {
 
     template <class Visitor, class T1, class T2, class T3, class... TN>
     inline BOOST_VARIANT_AUX_GENERIC_RESULT_TYPE(typename Visitor::result_type)
-        apply_visitor(const Visitor& visitor, T1& v1, T2& v2, T3& v3, TN&... vn)
+        apply_visitor(const Visitor& visitor, T1&& v1, T2&& v2, T3&& v3, TN&&... vn)
     {
         return ::boost::apply_visitor(
             ::boost::detail::variant::make_one_by_one_visitor_and_value_referer(
@@ -165,7 +165,7 @@ namespace detail { namespace variant {
     
     template <class Visitor, class T1, class T2, class T3, class... TN>
     inline BOOST_VARIANT_AUX_GENERIC_RESULT_TYPE(typename Visitor::result_type)
-        apply_visitor(Visitor& visitor, T1& v1, T2& v2, T3& v3, TN&... vn)
+        apply_visitor(Visitor& visitor, T1&& v1, T2&& v2, T3&& v3, TN&&... vn)
     {
         return ::boost::apply_visitor(
             ::boost::detail::variant::make_one_by_one_visitor_and_value_referer(

--- a/include/boost/variant/detail/multivisitors_cpp14_based.hpp
+++ b/include/boost/variant/detail/multivisitors_cpp14_based.hpp
@@ -104,7 +104,7 @@ namespace detail { namespace variant {
 }} // namespace detail::variant
 
     template <class Visitor, class T1, class T2, class T3, class... TN>
-    inline decltype(auto) apply_visitor(const Visitor& visitor, T1& v1, T2& v2, T3& v3, TN&... vn,
+    inline decltype(auto) apply_visitor(const Visitor& visitor, T1&& v1, T2&& v2, T3&& v3, TN&&... vn,
         typename boost::disable_if<
             boost::detail::variant::has_result_type<Visitor>
         >::type* = 0)
@@ -121,7 +121,7 @@ namespace detail { namespace variant {
     
 
     template <class Visitor, class T1, class T2, class T3, class... TN>
-    inline decltype(auto) apply_visitor(Visitor& visitor, T1& v1, T2& v2, T3& v3, TN&... vn,
+    inline decltype(auto) apply_visitor(Visitor& visitor, T1&& v1, T2&& v2, T3&& v3, TN&&... vn,
         typename boost::disable_if<
             boost::detail::variant::has_result_type<Visitor>
         >::type* = 0)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -53,6 +53,7 @@ test-suite variant
     [ run overload_selection.cpp ]
     [ run recursive_wrapper_move_test.cpp ]
     [ run variant_over_joint_view_test.cpp ]
+    [ run const_ref_apply_visitor.cpp : : : <cxxflags>-std=c++14 ]
    ; 
 
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -53,7 +53,9 @@ test-suite variant
     [ run overload_selection.cpp ]
     [ run recursive_wrapper_move_test.cpp ]
     [ run variant_over_joint_view_test.cpp ]
-    [ run const_ref_apply_visitor.cpp : : : <cxxflags>-std=c++14 ]
+    [ run const_ref_apply_visitor.cpp : : : <cxxflags>-std=c++14 : apply_visitor_cpp14 ]
+    [ run const_ref_apply_visitor.cpp : : : <cxxflags>-std=c++11 : apply_visitor_cpp11 ]
+    [ run const_ref_apply_visitor.cpp : : : : apply_visitor_cpp03 ]
    ; 
 
 

--- a/test/const_ref_apply_visitor.cpp
+++ b/test/const_ref_apply_visitor.cpp
@@ -1,0 +1,167 @@
+//-----------------------------------------------------------------------------
+// boost-libs variant/test/auto_visitors.cpp source file
+// See http://www.boost.org for updates, documentation, and revision history.
+//-----------------------------------------------------------------------------
+
+#include "boost/config.hpp"
+
+#include "boost/test/minimal.hpp"
+#include "boost/variant.hpp"
+#include "boost/variant/apply_visitor.hpp"
+#include "boost/lexical_cast.hpp"
+
+#define lcs(val) boost::lexical_cast<std::string>(val)
+
+struct construction_logger
+{
+    int _val;
+
+    construction_logger(int val) : _val(val)
+    {
+        std::cout << _val << " constructed\n";
+    }
+
+    construction_logger(const construction_logger& cl) :
+        _val(cl._val)
+    {
+        std::cout << _val << " copy constructed\n";
+    }
+
+    construction_logger(construction_logger&& cl) :
+        _val(cl._val)
+    {
+        std::cout << _val << " move constructed\n";
+    }
+
+    friend std::ostream& operator << (std::ostream& os, const construction_logger& cl)
+    {
+        return os << cl._val;
+    }
+
+    friend std::istream& operator << (std::istream& is, construction_logger& cl)
+    {
+        return is >> cl._val;
+    }
+};
+
+struct lex_streamer_explicit : boost::static_visitor<std::string>
+{
+    template <class T>
+    std::string operator()(const T& val) const
+    {
+        return lcs(val);
+    }
+
+    template <class T, class V>
+    std::string operator()(const T& val, const V& val2) const
+    {
+        return lcs(val) + '+' + lcs(val2);
+    }
+};
+
+typedef boost::variant<construction_logger, std::string> variant_type;
+
+void test_const_ref_parameter(const variant_type& test_var)
+{
+    std::cout << "Testing const lvalue reference visitable\n";
+
+    BOOST_CHECK(boost::apply_visitor(lex_streamer_explicit(), test_var) == lcs(test_var));
+}
+
+void test_const_ref_parameter2(const variant_type& test_var, const variant_type& test_var2)
+{
+    std::cout << "Testing const lvalue reference visitable\n";
+
+    BOOST_CHECK(boost::apply_visitor(lex_streamer_explicit(), test_var, test_var2) == lcs(test_var) + '+' + lcs(test_var2));
+}
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+void test_rvalue_parameter(variant_type&& test_var)
+{
+    std::cout << "Testing rvalue visitable\n";
+
+    const auto expected_val = lcs(test_var);
+    BOOST_CHECK(boost::apply_visitor(lex_streamer_explicit(), std::move(test_var)) == expected_val);
+}
+
+void test_rvalue_parameter2(variant_type&& test_var, variant_type&& test_var2)
+{
+    std::cout << "Testing rvalue visitable\n";
+
+    const auto expected_val = lcs(test_var) + '+' + lcs(test_var2);
+    BOOST_CHECK(boost::apply_visitor(lex_streamer_explicit(), std::move(test_var), std::move(test_var2)) == expected_val);
+}
+
+#endif
+
+#ifndef BOOST_NO_CXX14_DECLTYPE_AUTO
+
+void test_cpp14_visitor(const variant_type& test_var)
+{
+    std::cout << "Testing const lvalue visitable for c++14\n";
+
+    BOOST_CHECK(boost::apply_visitor([](auto&& v) { return lcs(v); }, test_var) == lcs(test_var));
+}
+
+void test_cpp14_visitor(const variant_type& test_var, const variant_type& test_var2)
+{
+    std::cout << "Testing const lvalue visitable for c++14\n";
+
+    BOOST_CHECK(boost::apply_visitor([](auto&& v, auto&& vv) { return lcs(v) + '+' + lcs(vv); }, test_var, test_var2) == lcs(test_var) + '+' + lcs(test_var2));
+}
+
+void test_cpp14_visitor(variant_type&& test_var)
+{
+    std::cout << "Testing const rvalue visitable for c++14\n";
+
+    const auto expected_val = lcs(test_var);
+    BOOST_CHECK(boost::apply_visitor([](auto&& v) { return lcs(v); }, test_var) == expected_val);
+}
+
+void test_cpp14_visitor(variant_type&& test_var, variant_type&& test_var2)
+{
+    std::cout << "Testing const rvalue visitable for c++14\n";
+
+    const auto expected_val = lcs(test_var) + '+' + lcs(test_var2);
+    BOOST_CHECK(boost::apply_visitor([](auto&& v, auto&& vv) { return lcs(v) + '+' + lcs(vv); }, std::move(test_var), std::move(test_var2)) == expected_val);
+}
+
+#endif
+
+void run()
+{
+    {
+        const variant_type v1(1), v2(2);
+        test_const_ref_parameter(v1);
+        test_const_ref_parameter2(v1, v2);
+    }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    {
+        variant_type v1(10), v2(20), v3(30);
+        test_rvalue_parameter(boost::move(v1));
+        test_rvalue_parameter2(boost::move(v2), boost::move(v3));
+    }
+#endif
+
+#ifndef BOOST_NO_CXX14_DECLTYPE_AUTO
+    {
+        variant_type v1(10), v2(20), v3(30);
+
+        test_cpp14_visitor(v1);
+        test_cpp14_visitor(v2, v3);
+
+        test_cpp14_visitor(boost::move(v1));
+        test_cpp14_visitor(boost::move(v2), boost::move(v3));
+    }
+#endif
+
+}
+
+int test_main(int , char* [])
+{
+    run();
+
+    return 0;
+}

--- a/test/const_ref_apply_visitor.cpp
+++ b/test/const_ref_apply_visitor.cpp
@@ -154,45 +154,46 @@ void test_cpp14_visitor(variant_type&& test_var, variant_type&& test_var2)
 
 #endif
 
-void run()
+void run_const_lvalue_ref_tests()
 {
-    {
         const variant_type v1(1), v2(2), v3(3), v4(4);
         test_const_ref_parameter(v1);
         test_const_ref_parameter2(v1, v2);
         test_const_ref_parameter4(v1, v2, v3, v4);
-    }
+}
 
+void run_rvalue_ref_tests()
+{
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-    {
-        variant_type v1(10), v2(20), v3(30);
-        test_rvalue_parameter(boost::move(v1));
-        test_rvalue_parameter2(boost::move(v2), boost::move(v3));
+    variant_type v1(10), v2(20), v3(30);
+    test_rvalue_parameter(boost::move(v1));
+    test_rvalue_parameter2(boost::move(v2), boost::move(v3));
 
-        variant_type vv1(100), vv2(200), vv3(300), vv4(400);
-        test_rvalue_parameter4(boost::move(vv1), boost::move(vv2), boost::move(vv3), boost::move(vv4));
-    }
+    variant_type vv1(100), vv2(200), vv3(300), vv4(400);
+    test_rvalue_parameter4(boost::move(vv1), boost::move(vv2), boost::move(vv3), boost::move(vv4));
 #endif
+}
 
+void run_cpp14_tests()
+{
 #ifndef BOOST_NO_CXX14_DECLTYPE_AUTO
-    {
-        variant_type v1(10), v2(20), v3(30);
+    variant_type v1(10), v2(20), v3(30);
 
-        test_cpp14_visitor(v1);
-        test_cpp14_visitor(v2, v3);
+    test_cpp14_visitor(v1);
+    test_cpp14_visitor(v2, v3);
 
-        test_cpp14_visitor(boost::move(v1));
-        test_cpp14_visitor(boost::move(v2), boost::move(v3));
+    test_cpp14_visitor(boost::move(v1));
+    test_cpp14_visitor(boost::move(v2), boost::move(v3));
 
-        //lambda visitors doesn't support multivisotors
-    }
+    //lambda visitors doesn't support multivisotors
 #endif
-
 }
 
 int test_main(int , char* [])
 {
-    run();
+    run_const_lvalue_ref_tests();
+    run_rvalue_ref_tests();
+    run_cpp14_tests();
 
     return 0;
 }

--- a/test/const_ref_apply_visitor.cpp
+++ b/test/const_ref_apply_visitor.cpp
@@ -27,11 +27,13 @@ struct construction_logger
         std::cout << _val << " copy constructed\n";
     }
 
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
     construction_logger(construction_logger&& cl) :
         _val(cl._val)
     {
         std::cout << _val << " move constructed\n";
     }
+#endif
 
     friend std::ostream& operator << (std::ostream& os, const construction_logger& cl)
     {


### PR DESCRIPTION
Attempt to fix [ticket #6971](https://svn.boost.org/trac10/ticket/6971)
Using universal references on cpp11 and cpp17, nothing changed on cpp03.
Delayed visitors not affected.